### PR TITLE
redirects to home page after signing up 

### DIFF
--- a/Frontend/src/pages/Signup.js
+++ b/Frontend/src/pages/Signup.js
@@ -53,6 +53,7 @@ function Signup() {
 				.then((response) => {
 					setUserData(response.data);
 				})
+				.then(window.location.replace('/'))
 
 			// ...
 		} catch (error) {


### PR DESCRIPTION
Todo: React 'cannot read username (null)' still flickers for an instant before redirecting to the home page. Most likely can be solved with a promise somewhere or possibly tinkering with firebease's `onAuthStateChanged`. 